### PR TITLE
Add strong bcs to laplace pc (still not right...)

### DIFF
--- a/thwaites/vertical_lumping.py
+++ b/thwaites/vertical_lumping.py
@@ -88,7 +88,7 @@ class LaplacePC(AuxiliaryOperatorPC):
     _prefix = "laplace_"  # prefix for solver parameters
 
     def form(self, pc, test, trial):
-        # returns the form from which the operator is assembled, and any bcs (None here)
+        # returns the form from which the operator is assembled, and any strong bcs (defaults to None here)
         _, P = pc.getOperators()
         ctx = P.getPythonContext()
         dt = ctx.appctx['dt']
@@ -96,6 +96,16 @@ class LaplacePC(AuxiliaryOperatorPC):
         ds = ctx.appctx['ds']
         bcs = ctx.appctx['bcs']
         n = ctx.appctx['n']
+        strong_bcs = ctx.appctx['strong_bcs']
+
+        laplace_strong_bcs = [DirichletBC(test.function_space(), 0, bci.sub_domain) for bci in strong_bcs]
+        for bci in strong_bcs:
+            print("bci.sub_domain", bci.sub_domain)
+
+        print('laplace pc')
+        print('test fs', test.function_space())
+        print('strong bcs fs', strong_bcs[0].function_space())
+        print('strong bcs fs', laplace_strong_bcs[0].function_space())
 
         F = dt * dt * dot(grad(test), grad(trial)) * dx
         F -= dt * dt * trial * dot(grad(test), n) * ds   # dirichlet pressure - default remove this term because open boundary.
@@ -112,4 +122,4 @@ class LaplacePC(AuxiliaryOperatorPC):
                 F += dt * dt * trial * dot(grad(test), n) * ds(id)
                 F += dt * dt * test * dot(grad(trial), n) * ds(id)
 
-        return F, None
+        return F, laplace_strong_bcs


### PR DESCRIPTION
Adding strong bcs to laplace pc to try and fix issue #9 

It now starts to go past the first initialise pressure step but I do not think the pressure field is right...! There is still a lot noise on the outside of  the domain for the pressure in the stretched regions. Interestingly the noice is actually much smaller under the crevasse where we have nearly isotropic cells. (in the x-z plane) 
![pressure_stripes_boundary](https://github.com/thwaitesproject/thwaites/assets/23333139/5cafae95-c996-420b-b167-ffd3c53ab09d)

Whereas with a tetrahedral P1dgP2 discretisation the noise in the pressure after the initialisation solve is ~1e-6 i.e. much lower than ~6 here... 
![pressure_boundary_p1dg2](https://github.com/thwaitesproject/thwaites/assets/23333139/b1c66892-8aef-46ec-af54-214013999d58)



So maybe I need an outer FS1 CG? or the vertical lumping isnt working so well with this range of scales?
The mesh resolution should be varying in x from 250 m to 5 m and in z from 1 (at ice base) to 20m

The output from the log (with more monitor true residuals turned on for each solve ) is:
[23.05.24_extruded_pb_strongbc.txt](https://github.com/thwaitesproject/thwaites/files/15420062/23.05.24_extruded_pb_strongbc.txt)



